### PR TITLE
Adds support to manage consent for img and iframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ var cookify = new Cookify(
     trackingCallback,
     saveWithChange,
     saveByDefault,
-    cookieDefault
+    cookieDefault,
+    initCallback
 )
 ```
 
@@ -96,7 +97,9 @@ You have 3 ways to for saving. Use `accept` when you want the user to save the s
 ```html
 <div data-c-action="necessary">Necessary</div>
 ```
+### Enabling or disabling content
 
+#### Scripts
 That you are able to handle the scripts for the user selected types you need to set `data-c-script` where it is necessary. It is only possible to use the types that are used in the query names `data-c-check`. This will either work for scripts with import src or with inline scripts.
 
 **data-c-script="{string}"**
@@ -107,6 +110,15 @@ That you are able to handle the scripts for the user selected types you need to 
 <script type="text/plain" data-c-script="necessary">
   console.log(example)
 </script>
+```
+
+#### Iframes and Images
+Instead of changing the type Cookify will switch the `src` element of iframe or img tags depending on the consent given. For that `data-c-fallback` (used if no consent was given) and `data-c-src` (used if consent was given) need to be set. The `data-c-script` attribute will be used to determine the category as for scripts. It is recommended to set the src already to the fallback to avoid connections before cookify is initialized.
+
+```html
+<img data-c-script="necessary" src="/path/to/fallback.jpg" data-c-fallback="/path/to/fallback.jpg" data-c-src="/example.jpg"/>
+
+<iframe data-c-script="necessary" src="about:blank" data-c-fallback="about:blank" data-c-src="https://example.org"></iframe>
 ```
 
 ### Helpers

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ export default class Cookify {
                     }
                 }
 
-                !checkChecked[type] && this.changeScriptType(type, 'js')
+                !checkChecked[type] && this.changeConsent(type, true)
                 checkChecked[type] = true
             }
         }
@@ -247,6 +247,34 @@ export default class Cookify {
     }
 
     /**
+     * Changes the src of html tags to either the original source or the fallback source depending on the consent
+     * @param {string} tag  html tag to search for eg img or iframe
+     * @param {string} category
+     * @param {boolean} consentGiven
+     */
+    changeSource(tag, category, consentGiven) {
+        var elements = document.querySelectorAll(tag + this.getQueryDataBrackets('script'))
+        for (const element of elements) {
+            if (element.getAttribute(this.getQueryData('script')) === category) {
+                var prop = consentGiven ? 'src' : 'fallback';
+                var src = element.getAttribute(this.getQueryData(prop));
+                element.setAttribute('src', src);
+            }
+        }
+    }
+
+    /**
+     * Enables or disables content on the page for a consent for a given category
+     * @param {string} category
+     * @param {boolean} consentGiven
+     */
+    changeConsent(category, consentGiven) {
+        this.changeScriptType(category, consentGiven ? 'js' : 'plain')
+        this.changeSource('img', category, consentGiven)
+        this.changeSource('iframe', category, consentGiven)
+    }
+
+    /**
      * Event Listeners
      */
 
@@ -261,7 +289,7 @@ export default class Cookify {
             cookieState = this.getDataState(type)
 
         cookieState = this.changeDataState(type, !cookieState)
-        this.saveWithChange && (cookieState ? this.changeScriptType(type, 'js') : this.changeScriptType(type, 'plain'))
+        this.saveWithChange && this.changeConsent(type, cookieState)
 
         for (const checkboxElement of checkboxElements) {
             cookieState ? checkboxElement.checked = 'checked' : checkboxElement.checked = false
@@ -274,7 +302,7 @@ export default class Cookify {
     onActionAcceptClick = () => {
         for (const type in this.data) {
             if (type != this.viewedName) {
-                this.data[type] ? this.changeScriptType(type, 'js') : this.changeScriptType(type, 'plain')
+                this.changeConsent(type, this.data[type])
             }
         }
         
@@ -291,7 +319,7 @@ export default class Cookify {
         for (const type in this.data) {
             if (type != this.cookieDefault && type != this.viewedName) {
                 this.data[type] = false
-                this.changeScriptType(type, 'plain')
+                this.changeConsent(type, false)
 
                 var checkboxElements = document.querySelectorAll('input' + this.getQueryDataBrackets('check', type))
 
@@ -314,7 +342,7 @@ export default class Cookify {
             this.data[type] = true
 
             if (type != this.viewedName) {
-                this.changeScriptType(type, 'js')
+                this.changeConsent(type, true)
 
                 var checkboxElements = document.querySelectorAll('input' + this.getQueryDataBrackets('check', type))
 


### PR DESCRIPTION
Besides scripts Cookify now can also manage activating or deactivating iframes and img tags based on the users consent.